### PR TITLE
Remove useless --ignore argument

### DIFF
--- a/airootfs/root/liveuser-desktop-settings/.bashrc
+++ b/airootfs/root/liveuser-desktop-settings/.bashrc
@@ -32,8 +32,8 @@ ShowInstallerIsoInfo() {
 
 
 alias ls='ls --color=auto'
-alias ll='ls -lav --ignore=..'   # show long listing of all except ".."
-alias l='ls -lav --ignore=.?*'   # show long listing but no hidden dotfiles except "."
+alias ll='ls -lAv'   # show long listing of all except ".."
+alias l='ls -lv'     # show long listing but no hidden dotfiles except "."
 
 [[ "$(whoami)" = "root" ]] && return
 


### PR DESCRIPTION
-a = all
-A = almost all (no ./..)