### PR TITLE
Update packages.x86_64 ipw2100-fw and ipw2200-fw have been removed from the repos.

### DIFF
--- a/packages.x86_64
+++ b/packages.x86_64
@@ -88,8 +88,6 @@ xorg-xrandr
 ## Network hardware
 b43-fwcutter
 broadcom-wl-dkms
-ipw2100-fw
-ipw2200-fw
 linux-atm
 
 ## General hardware


### PR DESCRIPTION
ipw2100-fw and ipw2200-fw have been removed from the repos.