### PR TITLE
Add "ibt=off" to kernel parameters list for Nvidia boot option

### DIFF
--- a/efiboot/loader/entries/archiso-x86_64-linux-nv.conf
+++ b/efiboot/loader/entries/archiso-x86_64-linux-nv.conf
@@ -4,4 +4,4 @@ linux   /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 initrd  /%INSTALL_DIR%/boot/intel-ucode.img
 initrd  /%INSTALL_DIR%/boot/amd-ucode.img
 initrd  /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=10G nvidia nvidia-drm.modeset=1 nouveau.modeset=0 i915.modeset=1 radeon.modeset=1 nvme_load=yes module_blacklist=pcspkr
+options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=10G nvidia nvidia-drm.modeset=1 nouveau.modeset=0 i915.modeset=1 radeon.modeset=1 nvme_load=yes module_blacklist=pcspkr ibt=off


### PR DESCRIPTION
Adds "ibt=off" to kernel parameters list for Nvidia boot option. Without this, Nvidia module fails to load if ISO is booted on Intel Gen11 or newer. More info here:
https://forum.garudalinux.org/t/nvidia-gpu-users-watch-out-for-kernel-5-18-update/19923