### PR TITLE
Remove file-roller

### DIFF
--- a/packages.x86_64
+++ b/packages.x86_64
@@ -235,9 +235,6 @@ xsettingsd
 ## Editor
 kate
 
-## Archive
-file-roller
-
 ## Browser
 firefox
 


### PR DESCRIPTION
This seems to be left over from Xfce.

We are already installing `ark` with the KDE packages.