### PR TITLE
Remove package xf86-video-vmware

### DIFF
--- a/packages.x86_64
+++ b/packages.x86_64
@@ -298,5 +298,4 @@ virtualbox-guest-utils
 ## VMware
 open-vm-tools
 xf86-input-vmmouse
-xf86-video-vmware
 xf86-video-qxl


### PR DESCRIPTION
The package "xf86-video-vmware 13.4.0-4" has been removed from the [extra] repository.