### PR TITLE
add accessibility feature to the UEFI bootloader

### DIFF
--- a/efiboot/loader/loader.conf
+++ b/efiboot/loader/loader.conf
@@ -1,3 +1,3 @@
 default archiso-x86_64-linux.conf
 timeout 10
-
+beep on


### PR DESCRIPTION
Just like in Arch Linux, there are beeps while in systemd-boot