### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 # Galileo Neo (2024)
 * fixing issue with changed license package (path changes) in mkarchiso
-* adding legacy intel fix to disable compositor on LiveSession if legacy intel with xf86-video-intel ist in use to reduce graphical issues.
+* adding legacy intel fix to disable compositor on LiveSession if legacy intel with xf86-video-intel is in use to reduce graphical issues.
 
 # Development start for Galileo Release (2023)
 * replacing xfce4 Live Session with KDE
@@ -44,14 +44,14 @@
 * adding systemd service to detect intel legacy GPUs and install xf86-video-intel in case for them.
 
 # For Artemis NOVA (September 2022)
-* using latest stabel 3.2 calamares version again 3.2.61 (locales are fixed)
+* using latest stable 3.2 calamares version again 3.2.61 (locales are fixed)
 * implementing pacman.conf with endeavouros-repo on top
 * setting grub almoszt vanilla
 * changing Community Editions package to fit name change (ttf-nerd-fonts-symbols-2048-em)
 
-# for Artemis neo (August 2022) 
+# for Artemis neo (August 2022)
 * we use calamares 3.2.59 version because of: https://github.com/calamares/calamares/issues/2008
-* packages injection install needs downgraded xkeyboard-config (to show letters on example keyboards inside calamares) 
+* packages injection install needs downgraded xkeyboard-config (to show letters on example keyboards inside calamares)
  and the eos-theming-package (10.0-1) to hold theming for neo.
 * https://archive.archlinux.org/packages/x/xkeyboard-config/xkeyboard-config-2.35.1-1-any.pkg.tar.zst
 * https://github.com/endeavouros-team/endeavouros-theming/tree/artemis_neo
@@ -65,13 +65,13 @@ and:
 
 are in sync now :clap: :partying_face:
 
-And will be easy to maintain in the future also if we go to split `chrooted_cleaner_script.sh` in to more logical pices, where the `clean_offline_packages` could be one module. 
+And will be easy to maintain in the future also if we go to split `chrooted_cleaner_script.sh` in to more logical pices, where the `clean_offline_packages` could be one module.
 
 [run_before_squashfs.sh](https://github.com/endeavouros-team/EndeavourOS-ISO/blob/main/run_before_squashfs.sh)
 
-look at it its clean and really slick now! The way it creates and handles liveuser session clean and easy to handle now without the hustle to fight with permissions and copy single config by config all over the place. 
+look at it its clean and really slick now! The way it creates and handles liveuser session clean and easy to handle now without the hustle to fight with permissions and copy single config by config all over the place.
 
-instead it creates a package with all the settings you can find in one folder using skel method and cleanly removes that after user creation. 
+instead it creates a package with all the settings you can find in one folder using skel method and cleanly removes that after user creation.
 
 All over file permissions are now handled centralized in the way archiso gives:
 [profiledef.sh](https://github.com/endeavouros-team/EndeavourOS-ISO/blob/main/profiledef.sh)
@@ -87,7 +87,7 @@ Remove legacy code from `run_before_squashfs.sh`
 
 # October 2021
 
-New merged repository structure (october 2021) by joekamprad. 
+New merged repository structure (october 2021) by joekamprad.
 Now live-user-desktop-settings are included under /airootfs/root/liveuser-desktop-settings
 First step on clean up the naturally grown ISO structure..
 

--- a/mkarchiso
+++ b/mkarchiso
@@ -501,7 +501,7 @@ _make_bootmode_bios.syslinux() {
             "${isofs_dir}/boot/syslinux/hdt/modalias.gz"
     fi
 
-    # Add other aditional/extra files to ${install_dir}/boot/
+    # Add other additional/extra files to ${install_dir}/boot/
     if [[ -e "${pacstrap_dir}/boot/memtest86+/memtest.bin" ]]; then
         install -d -m 0755 -- "${isofs_dir}/boot/memtest86+/"
         # rename for PXE: https://wiki.archlinux.org/title/Syslinux#Using_memtest
@@ -955,7 +955,7 @@ _validate_requirements_bootmode_bios.syslinux() {
     # Check for optional packages
     # shellcheck disable=SC2076
     if [[ ! " ${pkg_list[*]} " =~ ' memtest86+ ' ]]; then
-        _msg_info "Validating '${bootmode}': 'memtest86+' is not in the package list. Memmory testing will not be available from syslinux."
+        _msg_info "Validating '${bootmode}': 'memtest86+' is not in the package list. Memory testing will not be available from syslinux."
     fi
 }
 

--- a/run_before_squashfs.sh
+++ b/run_before_squashfs.sh
@@ -9,7 +9,7 @@ script_path=$(readlink -f "${0%/*}")
 work_dir="work"
 
 # Adapted from AIS. An excellent bit of code!
-# all pathes must be in quotation marks "path/to/file/or/folder" for now.
+# all paths must be in quotation marks "path/to/file/or/folder" for now.
 
 arch_chroot() {
     arch-chroot "${script_path}/${work_dir}/x86_64/airootfs" /bin/bash -c "${1}"
@@ -66,7 +66,7 @@ echo "---> Add builddate to motd --->"
 cat "/usr/lib/endeavouros-release" >> "/etc/motd"
 echo "------------------" >> "/etc/motd"
 
-echo "---> Install locally builded packages on ISO (place packages under airootfs/root/packages) --->"
+echo "---> Install locally built packages on ISO (place packages under airootfs/root/packages) --->"
 echo "--> content of /root/packages:"
 ls "/root/packages/"
 echo "end of content of /root/packages. <---"


### PR DESCRIPTION
- correct Galileo Neo and Artemis NOVA release notes wording in the changelog @CHANGELOG.md#36-48
- clean up spelling in mkarchiso syslinux comment and memtest hint @mkarchiso#504-959
- adjust run_before_squashfs path guidance and locally built package message @run_before_squashfs.sh#12-75

Author: rezky_nightky <with.rezky@gmail.com>
Timestamp: 2025-12-04T17:34:06Z
Repository: EndeavourOS-ISO
Branch: main
Signing: GPG (989AF9F0)
Performance: 3 files, +12/-12 lines